### PR TITLE
feat: Add OpenTofu and Vault topics with documentation and examples

### DIFF
--- a/topics/opentofu/README.md
+++ b/topics/opentofu/README.md
@@ -1,0 +1,173 @@
+## 1. What is OpenTofu?
+
+- https://opentofu.org/docs/intro/
+
+### Overview
+
+OpenTofu is an open-source Infrastructure as Code (IaC) tool that is a fork of Terraform, maintained by the Linux Foundation. It was created in response to HashiCorp's license change from MPL to the Business Source License (BSL) in August 2023.
+
+OpenTofu is:
+- **Drop-in replacement for Terraform**: Fully compatible with existing Terraform configurations (HCL syntax, providers, modules, state files)
+- **Open source**: Licensed under MPL 2.0, governed by the Linux Foundation
+- **Community-driven**: Backed by major companies including AWS, Google, IBM, Red Hat, and many others
+- **Feature-rich**: Includes all Terraform features plus new additions like state encryption and enhanced test framework
+
+### OpenTofu vs Terraform
+
+| Feature | OpenTofu | Terraform |
+|---------|----------|-----------|
+| License | MPL 2.0 (open source) | BSL 1.1 (source available) |
+| Governance | Linux Foundation | HashiCorp / IBM |
+| State encryption | ✅ Built-in | ❌ Not available |
+| Provider compatibility | ✅ Same as Terraform | ✅ Native |
+| Module registry | registry.opentofu.org | registry.terraform.io |
+| Community | Open contributors | HashiCorp-controlled |
+
+### Official Documentation
+
+- https://opentofu.org/docs/
+
+## 2. Prerequisites
+
+- Basic Linux command-line skills
+- Understanding of Infrastructure as Code concepts
+- Cloud provider account (AWS, Azure, or GCP) for cloud examples
+
+## 3. Installation
+
+### Install OpenTofu
+
+- Official guide: https://opentofu.org/docs/intro/install/
+
+```bash
+# macOS
+brew install opentofu
+
+# Linux (official installer)
+curl --proto '=https' --tlsv1.2 -fsSL https://get.opentofu.org/install-opentofu.sh | sh
+
+# Verify installation
+tofu version
+```
+
+### Migrate from Terraform
+
+```bash
+# OpenTofu is CLI-compatible with Terraform
+# Simply replace 'terraform' with 'tofu' in your commands
+terraform init    →  tofu init
+terraform plan    →  tofu plan
+terraform apply   →  tofu apply
+terraform destroy →  tofu destroy
+```
+
+## 4. Basics of OpenTofu
+
+### OpenTofu Hello World
+
+- See: [basics/](./basics/)
+
+### Core Workflow
+
+```bash
+# Initialize working directory (downloads providers)
+tofu init
+
+# Preview infrastructure changes
+tofu plan
+
+# Apply the changes
+tofu apply
+
+# Show current state
+tofu show
+
+# Destroy all managed infrastructure
+tofu destroy
+```
+
+### Basic Configuration Example
+
+```hcl
+# main.tf
+terraform {
+  required_providers {
+    local = {
+      source  = "hashicorp/local"
+      version = "~> 2.4"
+    }
+  }
+}
+
+resource "local_file" "hello" {
+  content  = "Hello from OpenTofu!"
+  filename = "${path.module}/hello.txt"
+}
+
+output "file_content" {
+  value = local_file.hello.content
+}
+```
+
+## 5. Beyond the Basics
+
+### State Encryption (OpenTofu-exclusive feature)
+
+```hcl
+# Encrypt state with a passphrase (OpenTofu only)
+terraform {
+  encryption {
+    key_provider "pbkdf2" "my_passphrase" {
+      passphrase = var.state_passphrase
+    }
+    method "aes_gcm" "my_method" {
+      keys = key_provider.pbkdf2.my_passphrase
+    }
+    state {
+      method = method.aes_gcm.my_method
+    }
+  }
+}
+```
+
+### Testing with OpenTofu
+
+```hcl
+# tests/basic.tftest.hcl
+run "verify_file_created" {
+  command = apply
+
+  assert {
+    condition     = local_file.hello.content == "Hello from OpenTofu!"
+    error_message = "File content does not match expected value"
+  }
+}
+```
+
+### Hands-On Examples
+
+- See: [practice/](./practice/)
+
+## 6. More
+
+### OpenTofu Cheatsheet
+
+```bash
+tofu init          # Initialize directory
+tofu validate      # Validate configuration
+tofu plan          # Show execution plan
+tofu apply         # Apply changes
+tofu apply -auto-approve  # Apply without confirmation
+tofu destroy       # Destroy infrastructure
+tofu state list    # List resources in state
+tofu state show <resource>  # Show resource details
+tofu output        # Show output values
+tofu fmt           # Format configuration files
+```
+
+### Recommended Resources
+
+- [OpenTofu Official Docs](https://opentofu.org/docs/)
+- [OpenTofu GitHub](https://github.com/opentofu/opentofu)
+- [OpenTofu Registry](https://registry.opentofu.org/)
+- [Migration Guide from Terraform](https://opentofu.org/docs/intro/migration/)

--- a/topics/opentofu/basics/README.md
+++ b/topics/opentofu/basics/README.md
@@ -1,0 +1,5 @@
+# Basics of OpenTofu
+
+## Demo
+
+Run `./opentofu_helloworld.sh` to create a simple local file resource with OpenTofu.

--- a/topics/opentofu/basics/opentofu_helloworld.sh
+++ b/topics/opentofu/basics/opentofu_helloworld.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+# OpenTofu Hello World - creates a local file resource to demonstrate the basic workflow
+
+set -e
+
+WORKDIR=$(mktemp -d)
+trap 'rm -rf "$WORKDIR"' EXIT
+
+echo "==> Creating OpenTofu configuration in ${WORKDIR}..."
+cat > "${WORKDIR}/main.tf" <<'EOF'
+terraform {
+  required_providers {
+    local = {
+      source  = "hashicorp/local"
+      version = "~> 2.4"
+    }
+  }
+}
+
+resource "local_file" "hello" {
+  content  = "Hello from OpenTofu! Infrastructure as Code made simple."
+  filename = "${path.module}/hello.txt"
+}
+
+output "message" {
+  value = local_file.hello.content
+}
+EOF
+
+cd "${WORKDIR}"
+
+echo "==> OpenTofu version:"
+tofu version
+
+echo ""
+echo "==> Initializing OpenTofu..."
+tofu init
+
+echo ""
+echo "==> Planning infrastructure changes..."
+tofu plan
+
+echo ""
+echo "==> Applying configuration..."
+tofu apply -auto-approve
+
+echo ""
+echo "==> Showing outputs..."
+tofu output
+
+echo ""
+echo "==> File created:"
+cat hello.txt
+
+echo ""
+echo "==> Current state:"
+tofu state list
+
+echo ""
+echo "==> Destroying resources..."
+tofu destroy -auto-approve
+
+echo ""
+echo "==> Done! OpenTofu Hello World complete."

--- a/topics/opentofu/practice/README.md
+++ b/topics/opentofu/practice/README.md
@@ -1,0 +1,58 @@
+# OpenTofu Practice
+
+## Exercises
+
+### Exercise 1: Local Resources (No Cloud Required)
+
+1. Create an OpenTofu configuration that generates multiple local files
+2. Use `count` or `for_each` to create 3 files with different content
+3. Use variables and outputs
+4. Run `tofu plan`, `tofu apply`, verify the files, then `tofu destroy`
+
+**Goal**: Get comfortable with the core OpenTofu workflow
+
+---
+
+### Exercise 2: Migrate from Terraform to OpenTofu
+
+1. Take an existing Terraform configuration (or use one from `topics/terraform/basics/`)
+2. Follow the migration guide: https://opentofu.org/docs/intro/migration/
+3. Run `tofu init -upgrade` to migrate
+4. Verify state is intact with `tofu state list`
+5. Run `tofu plan` and confirm no changes are detected
+
+**Goal**: Understand OpenTofu's Terraform compatibility
+
+---
+
+### Exercise 3: State Encryption (OpenTofu-Exclusive)
+
+1. Create a simple configuration with a local resource
+2. Add an `encryption` block using the `pbkdf2` key provider
+3. Apply the configuration — observe the state file is now encrypted
+4. Verify you cannot read the state file directly with `cat`
+5. Run `tofu state list` to confirm Tofu can still read it
+
+**Reference**: https://opentofu.org/docs/language/state/encryption/
+
+---
+
+### Exercise 4: Writing and Running Tests
+
+1. Create a module that manages a local directory structure
+2. Write a `.tftest.hcl` test file with at least 2 test cases
+3. Run `tofu test` and observe results
+4. Intentionally break a test assertion to see the failure output
+
+**Reference**: https://opentofu.org/docs/language/tests/
+
+---
+
+### Exercise 5: Provider Configuration with Multiple Environments
+
+1. Create a configuration with `dev` and `prod` workspaces
+2. Use `terraform.workspace` to set different values per environment
+3. Use `tofu workspace new dev` and `tofu workspace new prod`
+4. Apply to each workspace and compare state files
+
+**Reference**: https://opentofu.org/docs/language/state/workspaces/

--- a/topics/vault/README.md
+++ b/topics/vault/README.md
@@ -1,0 +1,152 @@
+## 1. What is HashiCorp Vault?
+
+- https://developer.hashicorp.com/vault/docs/what-is-vault
+
+### Overview
+
+HashiCorp Vault is an identity-based secrets and encryption management system. It provides a secure, automated way to manage secrets, credentials, and sensitive data across dynamic cloud environments.
+
+Key capabilities:
+- **Secrets management**: Store and tightly control access to tokens, passwords, certificates, API keys, and other secrets
+- **Dynamic secrets**: Generate secrets on-demand for AWS, databases, SSH, and more — they expire automatically
+- **Data encryption**: Encrypt application data without storing it in Vault
+- **Leasing and renewal**: All secrets in Vault have a lease; clients must renew before expiry
+- **Revocation**: Revoke secrets individually or by tree, enabling rolling credential rotation
+
+### Vault Architecture
+
+```
+                ┌──────────────────────────────────────┐
+                │              Vault Server             │
+                │  ┌────────────┐  ┌─────────────────┐ │
+Client ────────►│  │  Auth      │  │  Secret Engines │ │
+                │  │  Methods   │  │  - KV, PKI      │ │
+                │  │  - Token   │  │  - AWS, DB      │ │
+                │  │  - AppRole │  │  - SSH, Transit │ │
+                │  │  - K8s     │  └─────────────────┘ │
+                │  └────────────┘                       │
+                │  ┌─────────────────────────────────┐  │
+                │  │        Storage Backend          │  │
+                │  │  (Consul, Raft, S3, etcd...)    │  │
+                │  └─────────────────────────────────┘  │
+                └──────────────────────────────────────┘
+```
+
+### Official Documentation
+
+- https://developer.hashicorp.com/vault/docs
+
+## 2. Prerequisites
+
+- Basic Linux command-line skills
+- Understanding of secrets and credential management concepts
+- Docker (for running Vault in dev mode)
+
+## 3. Installation
+
+### Install Vault CLI
+
+- Official guide: https://developer.hashicorp.com/vault/install
+
+```bash
+# macOS
+brew tap hashicorp/tap
+brew install hashicorp/tap/vault
+
+# Linux (Ubuntu/Debian)
+wget -O- https://apt.releases.hashicorp.com/gpg | sudo gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg
+echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list
+sudo apt update && sudo apt install vault
+```
+
+### Run Vault in Dev Mode (Docker)
+
+```bash
+docker run --rm -p 8200:8200 \
+  -e 'VAULT_DEV_ROOT_TOKEN_ID=myroot' \
+  hashicorp/vault
+```
+
+## 4. Basics of Vault
+
+### Vault Hello World
+
+- See: [basics/](./basics/)
+
+### Common Vault Commands
+
+```bash
+# Set Vault address and token
+export VAULT_ADDR='http://127.0.0.1:8200'
+export VAULT_TOKEN='myroot'
+
+# Check status
+vault status
+
+# Write a secret
+vault kv put secret/myapp username="admin" password="s3cr3t"
+
+# Read a secret
+vault kv get secret/myapp
+
+# Read only a specific field
+vault kv get -field=password secret/myapp
+
+# List secrets
+vault kv list secret/
+
+# Delete a secret
+vault kv delete secret/myapp
+```
+
+## 5. Beyond the Basics
+
+### Dynamic Secrets (AWS)
+
+Vault can generate short-lived AWS credentials on demand:
+
+```bash
+# Enable the AWS secrets engine
+vault secrets enable -path=aws aws
+
+# Configure AWS credentials
+vault write aws/config/root access_key=$AWS_ACCESS_KEY secret_key=$AWS_SECRET_KEY
+
+# Create a role
+vault write aws/roles/my-role credential_type=iam_user policy_arns=arn:aws:iam::aws:policy/AmazonEC2ReadOnlyAccess
+
+# Generate credentials
+vault read aws/creds/my-role
+```
+
+### Vault with Kubernetes
+
+- Official guide: https://developer.hashicorp.com/vault/docs/platform/k8s
+- Use the Vault Agent Sidecar Injector or the Vault Secrets Operator to inject secrets into Pods
+
+### Vault with Terraform
+
+```hcl
+provider "vault" {
+  address = "https://vault.example.com"
+}
+
+data "vault_kv_secret_v2" "example" {
+  mount = "secret"
+  name  = "myapp"
+}
+```
+
+### Hands-On Examples
+
+- See: [practice/](./practice/)
+
+## 6. More
+
+### Vault Cheatsheet
+
+- https://developer.hashicorp.com/vault/docs/commands
+
+### Recommended Books
+
+- [HashiCorp Vault: Securing Secrets at Scale](https://www.oreilly.com/library/view/hashicorp-vault-securing/9781098116644/)

--- a/topics/vault/basics/README.md
+++ b/topics/vault/basics/README.md
@@ -1,0 +1,5 @@
+# Basics of Vault
+
+## Demo
+
+Run `./vault_helloworld.sh` to start Vault in dev mode and write/read a secret.

--- a/topics/vault/basics/vault_helloworld.sh
+++ b/topics/vault/basics/vault_helloworld.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+# Vault Hello World - starts Vault dev server and demonstrates basic secret operations
+
+set -e
+
+VAULT_ADDR="http://127.0.0.1:8200"
+VAULT_TOKEN="myroot"
+
+echo "==> Starting Vault dev server in background..."
+docker run -d --rm --name vault-dev \
+  -p 8200:8200 \
+  -e "VAULT_DEV_ROOT_TOKEN_ID=${VAULT_TOKEN}" \
+  hashicorp/vault
+
+echo "==> Waiting for Vault to be ready..."
+sleep 3
+
+export VAULT_ADDR
+export VAULT_TOKEN
+
+echo "==> Vault status:"
+vault status
+
+echo ""
+echo "==> Writing a secret..."
+vault kv put secret/devops-basics \
+  username="admin" \
+  password="supersecret" \
+  environment="demo"
+
+echo ""
+echo "==> Reading the secret back..."
+vault kv get secret/devops-basics
+
+echo ""
+echo "==> Reading a specific field..."
+PASS=$(vault kv get -field=password secret/devops-basics)
+echo "Password field: ${PASS}"
+
+echo ""
+echo "==> Listing secrets..."
+vault kv list secret/
+
+echo ""
+echo "==> Deleting the secret..."
+vault kv delete secret/devops-basics
+
+echo ""
+echo "==> Cleaning up: stopping Vault container..."
+docker stop vault-dev
+
+echo "==> Done! Vault Hello World complete."

--- a/topics/vault/practice/README.md
+++ b/topics/vault/practice/README.md
@@ -1,0 +1,64 @@
+# Vault Practice
+
+## Exercises
+
+### Exercise 1: KV Secrets Engine
+
+1. Start Vault in dev mode
+2. Enable the `kv-v2` secrets engine at path `secret/`
+3. Store database credentials (host, port, username, password) under `secret/database/postgres`
+4. Read them back using `vault kv get`
+5. Update the password and verify the new version is stored
+6. Roll back to version 1
+
+**Reference**: https://developer.hashicorp.com/vault/docs/secrets/kv/kv-v2
+
+---
+
+### Exercise 2: AppRole Authentication
+
+1. Enable the AppRole auth method
+2. Create a policy that allows read access to `secret/data/myapp/*`
+3. Create a role with that policy attached
+4. Retrieve a `role_id` and generate a `secret_id`
+5. Login using AppRole to get a token
+6. Use that token to read a secret
+
+**Reference**: https://developer.hashicorp.com/vault/docs/auth/approle
+
+---
+
+### Exercise 3: Vault with Kubernetes (Vault Agent Injector)
+
+1. Install Vault on a local Kubernetes cluster using Helm
+2. Configure Kubernetes authentication in Vault
+3. Deploy the Vault Agent Injector
+4. Create a sample app with Vault annotations to inject a secret as a file
+5. Verify the secret appears in `/vault/secrets/` inside the pod
+
+**Reference**: https://developer.hashicorp.com/vault/docs/platform/k8s/injector
+
+---
+
+### Exercise 4: Dynamic Database Credentials
+
+1. Start a PostgreSQL container
+2. Enable the database secrets engine in Vault
+3. Configure Vault with PostgreSQL connection details
+4. Create a role that generates short-lived credentials
+5. Generate credentials and connect to PostgreSQL
+6. Observe that the credentials expire automatically
+
+**Reference**: https://developer.hashicorp.com/vault/docs/secrets/databases/postgresql
+
+---
+
+### Exercise 5: Transit Secrets Engine (Encryption as a Service)
+
+1. Enable the transit secrets engine
+2. Create an encryption key named `my-key`
+3. Encrypt a plaintext string via the API
+4. Decrypt it back to verify round-trip
+5. Rotate the key and verify existing ciphertext can still be decrypted
+
+**Reference**: https://developer.hashicorp.com/vault/docs/secrets/transit


### PR DESCRIPTION
Add two new DevOps topics — OpenTofu (open-source Terraform fork) and HashiCorp Vault (secrets management) — each with README, basics hello-world script, and practice directory, following the existing topic structure.