### PR TITLE
Add Trivy topic

### DIFF
--- a/topics/trivy/README.md
+++ b/topics/trivy/README.md
@@ -1,0 +1,187 @@
+## 1. What is Trivy?
+
+- https://trivy.dev/latest/docs/
+
+### Overview
+
+Trivy is the world's most popular open-source vulnerability and misconfiguration scanner. Built by Aqua Security, it detects security issues across the entire software supply chain — container images, filesystems, Git repositories, Kubernetes clusters, and Infrastructure as Code.
+
+Trivy scans for:
+- **OS packages**: Alpine, Debian, Ubuntu, RHEL, CentOS, Amazon Linux, and more
+- **Language-specific packages**: npm, pip, gem, cargo, go modules, Maven, NuGet
+- **Infrastructure as Code**: Terraform, CloudFormation, Kubernetes, Helm, Dockerfile
+- **Kubernetes misconfigurations**: NSA/CISA hardening guidelines, CIS benchmarks
+- **Secrets**: Embedded credentials, API keys, tokens in code and images
+- **Licenses**: Open source license compliance
+
+### Trivy Architecture
+
+```
+                ┌─────────────────────────────────────────┐
+                │                Trivy CLI                 │
+                │  ┌──────────┐  ┌───────────────────────┐│
+Input ─────────►│  │  Scanner │  │      Detectors        ││
+(image/fs/repo) │  │          │  │  - Vulnerabilities    ││
+                │  │  ┌───────┤  │  - Misconfigurations  ││
+                │  │  │Parser │  │  - Secrets            ││
+                │  │  │ SBOM  │  │  - Licenses           ││
+                │  └──┴───────┘  └───────────────────────┘│
+                │         │                                │
+                │  ┌──────▼──────────────────────────────┐ │
+                │  │  Vulnerability DB (auto-updated)    │ │
+                │  │  NVD, GitHub Advisory, OSV, RedHat  │ │
+                │  └─────────────────────────────────────┘ │
+                └─────────────────────────────────────────┘
+```
+
+### Official Documentation
+
+- https://trivy.dev/latest/docs/
+- GitHub: https://github.com/aquasecurity/trivy
+
+## 2. Prerequisites
+
+- Docker (to scan container images)
+- Basic understanding of vulnerabilities and CVEs
+
+## 3. Installation
+
+### Install Trivy
+
+```bash
+# macOS
+brew install trivy
+
+# Linux (Ubuntu/Debian)
+sudo apt-get install wget apt-transport-https gnupg lsb-release
+wget -qO - https://aquasecurity.github.io/trivy-repo/deb/public.key | gpg --dearmor | sudo tee /usr/share/keyrings/trivy.gpg > /dev/null
+echo "deb [signed-by=/usr/share/keyrings/trivy.gpg] https://aquasecurity.github.io/trivy-repo/deb $(lsb_release -sc) main" | sudo tee -a /etc/apt/sources.list.d/trivy.list
+sudo apt-get update && sudo apt-get install trivy
+
+# Docker
+docker run aquasec/trivy
+
+# Verify
+trivy --version
+```
+
+- Official install guide: https://trivy.dev/latest/docs/getting-started/installation/
+
+## 4. Basics of Trivy
+
+### Trivy Hello World
+
+- See: [basics/](./basics/)
+
+### Scan a Container Image
+
+```bash
+# Scan an image for vulnerabilities
+trivy image nginx:latest
+
+# Scan only HIGH and CRITICAL
+trivy image --severity HIGH,CRITICAL nginx:latest
+
+# Output as JSON
+trivy image --format json --output result.json nginx:latest
+
+# Scan a local image
+trivy image myapp:local
+```
+
+### Scan a Filesystem or Repository
+
+```bash
+# Scan current directory
+trivy fs .
+
+# Scan a Git repository
+trivy repo https://github.com/knqyf263/trivy-ci-test
+
+# Scan for secrets
+trivy fs --scanners secret .
+
+# Scan IaC (Terraform, K8s manifests)
+trivy config ./terraform/
+```
+
+### Scan Kubernetes Cluster
+
+```bash
+# Scan entire cluster
+trivy k8s --report summary cluster
+
+# Scan a specific namespace
+trivy k8s --namespace production --report all cluster
+
+# Scan a specific workload
+trivy k8s deployment/myapp
+```
+
+## 5. Beyond the Basics
+
+### Integrate with GitHub Actions
+
+```yaml
+- name: Scan Docker image
+  uses: aquasecurity/trivy-action@master
+  with:
+    image-ref: 'myapp:${{ github.sha }}'
+    format: 'sarif'
+    output: 'trivy-results.sarif'
+    severity: 'CRITICAL,HIGH'
+
+- name: Upload results to GitHub Security
+  uses: github/codeql-action/upload-sarif@v3
+  with:
+    sarif_file: 'trivy-results.sarif'
+```
+
+### Generate SBOM (Software Bill of Materials)
+
+```bash
+# Generate SBOM in CycloneDX format
+trivy image --format cyclonedx --output sbom.json nginx:latest
+
+# Generate SBOM in SPDX format
+trivy image --format spdx-json --output sbom.spdx.json nginx:latest
+```
+
+### Policy as Code with Rego
+
+```bash
+# Use custom Rego policies for IaC scanning
+trivy config --policy ./policies/ ./kubernetes/
+```
+
+### Hands-On Examples
+
+- See: [practice/](./practice/)
+
+## 6. More
+
+### Trivy Cheatsheet
+
+```bash
+# Image scanning
+trivy image <image>                           # Scan image
+trivy image --severity HIGH,CRITICAL <image>  # Filter by severity
+trivy image --ignore-unfixed <image>          # Skip unfixed CVEs
+trivy image --format json <image>             # JSON output
+
+# Filesystem scanning
+trivy fs .                                    # Scan directory
+trivy fs --scanners vuln,secret,config .     # All scanners
+
+# Config/IaC scanning
+trivy config ./                               # Scan IaC files
+
+# Kubernetes
+trivy k8s cluster --report summary           # Cluster summary
+```
+
+### Recommended Resources
+
+- [Trivy Documentation](https://trivy.dev/latest/docs/)
+- [Trivy GitHub](https://github.com/aquasecurity/trivy)
+- [Aqua Security Blog](https://www.aquasec.com/blog/)

--- a/topics/trivy/basics/README.md
+++ b/topics/trivy/basics/README.md
@@ -1,0 +1,5 @@
+# Basics of Trivy
+
+## Demo
+
+Run `./trivy_scan_demo.sh` to scan a sample container image and filesystem for vulnerabilities.

--- a/topics/trivy/basics/trivy_scan_demo.sh
+++ b/topics/trivy/basics/trivy_scan_demo.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+# Trivy Scan Demo - demonstrates image and filesystem scanning
+
+set -e
+
+echo "==> Trivy version:"
+trivy --version
+
+echo ""
+echo "=============================="
+echo "1. Scanning a container image"
+echo "=============================="
+echo "Scanning nginx:1.24 for HIGH and CRITICAL vulnerabilities..."
+trivy image --severity HIGH,CRITICAL --no-progress nginx:1.24
+
+echo ""
+echo "================================"
+echo "2. Scanning a filesystem/IaC"
+echo "================================"
+TEMPDIR=$(mktemp -d)
+trap 'rm -rf "$TEMPDIR"' EXIT
+
+# Create a sample Dockerfile with a known issue
+cat > "${TEMPDIR}/Dockerfile" <<'EOF'
+FROM ubuntu:18.04
+RUN apt-get update && apt-get install -y curl
+USER root
+EOF
+
+# Create a sample Kubernetes manifest
+cat > "${TEMPDIR}/deployment.yaml" <<'EOF'
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: insecure-app
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: insecure
+  template:
+    metadata:
+      labels:
+        app: insecure
+    spec:
+      containers:
+      - name: app
+        image: nginx:latest
+        securityContext:
+          privileged: true
+          runAsRoot: true
+EOF
+
+echo "Scanning IaC files for misconfigurations..."
+trivy config --no-progress "${TEMPDIR}/"
+
+echo ""
+echo "==================================="
+echo "3. Scanning for secrets in a repo"
+echo "==================================="
+# Create a file with a fake secret pattern for demo
+cat > "${TEMPDIR}/config.env" <<'EOF'
+DATABASE_URL=postgres://user:password@localhost/db
+API_KEY=AKIAIOSFODNN7EXAMPLE
+EOF
+
+echo "Scanning for embedded secrets..."
+trivy fs --scanners secret --no-progress "${TEMPDIR}/" || true
+
+echo ""
+echo "==> Done! See the findings above."
+echo "==> Tip: Run 'trivy image --help' to explore more options."

--- a/topics/trivy/practice/README.md
+++ b/topics/trivy/practice/README.md
@@ -1,0 +1,61 @@
+# Trivy Practice
+
+## Exercises
+
+### Exercise 1: Scan and Fix a Container Image
+
+1. Scan `python:3.9` for CRITICAL vulnerabilities
+2. Run: `trivy image --severity CRITICAL python:3.9`
+3. Note the CVEs found
+4. Scan `python:3.12-slim` — compare the results
+5. Understand why using minimal/newer base images reduces your attack surface
+
+---
+
+### Exercise 2: IaC Misconfiguration Scanning
+
+1. Create a Terraform file defining an S3 bucket with public access enabled
+2. Scan it with: `trivy config ./`
+3. Note the misconfigurations flagged (ACL, versioning, encryption)
+4. Fix each finding and re-scan until it passes
+
+**Goal**: Practice secure IaC development with fast feedback
+
+---
+
+### Exercise 3: Integrate Trivy in GitHub Actions
+
+1. Create a `Dockerfile` for a simple Node.js app
+2. Add a GitHub Actions workflow that:
+   - Builds the Docker image
+   - Scans it with Trivy
+   - Fails the build if CRITICAL CVEs are found
+   - Uploads SARIF results to GitHub Security tab
+3. Intentionally use an older base image and observe the pipeline fail
+
+**Reference**: https://github.com/aquasecurity/trivy-action
+
+---
+
+### Exercise 4: Generate and Validate an SBOM
+
+1. Pull an image: `docker pull redis:7`
+2. Generate a CycloneDX SBOM: `trivy image --format cyclonedx --output sbom.json redis:7`
+3. Inspect the SBOM to list all components
+4. Use the SBOM to scan for vulnerabilities: `trivy sbom sbom.json`
+
+**Goal**: Understand Software Bill of Materials in supply chain security
+
+---
+
+### Exercise 5: Kubernetes Cluster Security Audit
+
+1. If you have a running Kubernetes cluster (minikube/kind), run:
+   ```bash
+   trivy k8s --report summary cluster
+   ```
+2. Review findings by category (vulnerabilities, misconfigurations)
+3. Pick one HIGH finding and research how to fix it
+4. Apply the fix and re-run to confirm remediation
+
+**Reference**: https://trivy.dev/latest/docs/target/kubernetes/


### PR DESCRIPTION
Add new DevOps topic for Trivy (open-source vulnerability/security scanner) with README, basics demo script, and practice directory, following the existing topic structure.