### PR TITLE
Add OpenTofu, Vault, Trivy, and GCP to README topics table

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,6 +376,38 @@ We cover a wide range of DevOps topics in our content library, explore them unde
         <td>✔️ <a href="./topics/grafana/basics/helloworld/">Explore</a></td>
         <td>🏃 <a href="./topics/grafana/practice/">Explore</a></td>
     </tr>
+    <tr>
+        <td><img height="28" src="https://avatars.githubusercontent.com/u/133243300" /></td>
+        <td>OpenTofu</td>
+        <td><a href="./topics/opentofu/">opentofu</a></td>
+        <td>📖 <a href="https://opentofu.org/docs/">View</a></td>
+        <td>✔️ <a href="./topics/opentofu/basics/">Explore</a></td>
+        <td>🏃 <a href="./topics/opentofu/practice/">Explore</a></td>
+    </tr>
+    <tr>
+        <td><img height="28" src="https://avatars.githubusercontent.com/u/761456" /></td>
+        <td>Vault</td>
+        <td><a href="./topics/vault/">vault</a></td>
+        <td>📖 <a href="https://developer.hashicorp.com/vault/docs">View</a></td>
+        <td>✔️ <a href="./topics/vault/basics/">Explore</a></td>
+        <td>🏃 <a href="./topics/vault/practice/">Explore</a></td>
+    </tr>
+    <tr>
+        <td><img height="28" src="https://avatars.githubusercontent.com/u/12783832" /></td>
+        <td>Trivy</td>
+        <td><a href="./topics/trivy/">trivy</a></td>
+        <td>📖 <a href="https://trivy.dev/latest/docs/">View</a></td>
+        <td>✔️ <a href="./topics/trivy/basics/">Explore</a></td>
+        <td>🏃 <a href="./topics/trivy/practice/">Explore</a></td>
+    </tr>
+    <tr>
+        <td><img height="28" src="https://skillicons.dev/icons?i=gcp" /></td>
+        <td>GCP</td>
+        <td><a href="./topics/gcp/">gcp</a></td>
+        <td>📖 <a href="https://cloud.google.com/docs">View</a></td>
+        <td>✔️ <a href="./topics/gcp/basics/">Explore</a></td>
+        <td>🏃 <a href="./topics/gcp/practice/">Explore</a></td>
+    </tr>
 </table>
 
 - And **more upcoming topics...⏩** you can star/follow this repository to get more up-to-dated content ⭐


### PR DESCRIPTION
Link the four newly added topics in the main README DevOps topics table with icon, content, docs, basics, and practice columns.
