### PR TITLE
feat(terraform): make EC2 instance_type configurable via variable

### DIFF
--- a/topics/terraform/basics/aws-ec2/main.tf
+++ b/topics/terraform/basics/aws-ec2/main.tf
@@ -15,7 +15,7 @@ provider "aws" {
 
 resource "aws_instance" "app_server" {
   ami           = var.ami_template
-  instance_type = "t2.micro"
+  instance_type = var.instance_type
 
   tags = {
     Name = var.instance_name

--- a/topics/terraform/basics/aws-ec2/variables.tf
+++ b/topics/terraform/basics/aws-ec2/variables.tf
@@ -16,3 +16,9 @@ variable "ami_template" {
   type        = string
   default     = "ami-018d291ca9ffc002f"
 }
+
+variable "instance_type" {
+  description = "Value of the EC2 instance type to provision"
+  type        = string
+  default     = "t2.micro"
+}


### PR DESCRIPTION
## What is the purpose of the change

The `topics/terraform/basics/aws-ec2` example hardcoded `instance_type` to
`t2.micro`, while every other setting in this example — `ami`, `region`,
and the `Name` tag — was already exposed as a variable. This made the
module inconsistent and less useful as a learning example, since trying a
different instance size required editing the module source directly.

This PR adds an `instance_type` variable (default: `t2.micro`, so existing
behavior is unchanged) and references it in `main.tf`, making the example
fully variable-driven and consistent with the rest of the file.

## Changes
- `variables.tf`: added `instance_type` variable
- `main.tf`: replaced hardcoded `"t2.micro"` with `var.instance_type`