### PR TITLE
feat(networking): add ssh basics and advanced topic

### DIFF
--- a/topics/ssh/README.md
+++ b/topics/ssh/README.md
@@ -1,0 +1,70 @@
+# SSH
+
+## 1. What is SSH?
+
+### Overview
+
+- SSH (Secure Shell) is a network protocol that allows secure, encrypted communication between two systems over an unsecured network.
+- It is most commonly used to remotely log into servers, execute commands, and transfer files (via SCP/SFTP), replacing older insecure protocols like Telnet and rlogin.
+- SSH uses public-key cryptography to authenticate the remote computer and, optionally, to authenticate the user.
+
+### Official website documentation of SSH
+
+- https://www.openssh.com/
+- https://www.ssh.com/academy/ssh/protocol
+
+## 2. Prerequisites
+
+- Basic Linux command line usage
+- Basic understanding of networking (client-server model, ports)
+
+## 3. Installation
+
+### How to install SSH?
+
+On most Linux distributions, the SSH client is installed by default. To install the SSH server:
+
+```bash
+# Debian/Ubuntu
+sudo apt update
+sudo apt install openssh-server -y
+sudo systemctl enable ssh
+sudo systemctl start ssh
+
+# RHEL/CentOS
+sudo yum install openssh-server -y
+sudo systemctl enable sshd
+sudo systemctl start sshd
+```
+
+Verify it's running:
+```bash
+sudo systemctl status ssh
+```
+
+## 4. Basics of SSH
+
+### Getting started with SSH
+
+- To get started visit **topics/ssh/basics**
+
+## 5. Beyond the Basics
+
+### Exploring Advanced Examples
+
+- To get more advanced examples/hands on visit **topics/ssh/advanced**
+
+## 6. More...
+
+### Cheatsheet
+
+- `ssh user@host` — connect to a remote host
+- `ssh -p 2222 user@host` — connect on a custom port
+- `ssh-keygen -t ed25519` — generate a new key pair
+- `ssh-copy-id user@host` — copy your public key to a remote host
+- `scp file.txt user@host:/path/` — copy a file to a remote host
+- `ssh -L 8080:localhost:80 user@host` — local port forwarding
+
+### Recommended Books
+
+- "SSH Mastery" by Michael W Lucas

--- a/topics/ssh/advanced/README.md
+++ b/topics/ssh/advanced/README.md
@@ -1,0 +1,5 @@
+# SSH Advanced
+
+## SSH Config file
+
+Instead of typing long commands every time, define hosts in `~/.ssh/config`:

--- a/topics/ssh/basics/README.md
+++ b/topics/ssh/basics/README.md
@@ -1,0 +1,42 @@
+# SSH Basics
+
+## Generate an SSH key pair
+
+```bash
+ssh-keygen -t ed25519 -C "your_email@example.com"
+```
+This creates two files by default:
+- `~/.ssh/id_ed25519` (private key — never share this)
+- `~/.ssh/id_ed25519.pub` (public key — safe to share)
+
+## Copy your public key to a remote server
+
+```bash
+ssh-copy-id user@remote-host
+```
+This appends your public key to `~/.ssh/authorized_keys` on the remote host, enabling passwordless login.
+
+## Connect to a remote server
+
+```bash
+ssh user@remote-host
+```
+
+## Connect using a specific key and port
+
+```bash
+ssh -i ~/.ssh/id_ed25519 -p 2222 user@remote-host
+```
+
+## View known hosts
+
+Every server you connect to gets fingerprinted in:
+```bash
+cat ~/.ssh/known_hosts
+```
+
+## Copy files with SCP
+
+```bash
+scp localfile.txt user@remote-host:/home/user/
+```


### PR DESCRIPTION
Closes: #698

## What is the purpose of the change

Adds a new `ssh` topic under `topics/ssh/`, following the repo's
TOPIC_TEMPLATE.md structure, as part of the "Add networking section" epic.

- `topics/ssh/README.md` — overview, prerequisites, installation, cheatsheet
- `topics/ssh/basics/README.md` — key generation, connecting, SCP
- `topics/ssh/advanced/README.md` — SSH config, port forwarding, jump hosts, hardening

This covers the `ssh` sub-topic from #698. The remaining sub-topics
(http/https, dns, proxy, load balancer) can be picked up in separate PRs.