### PR TITLE
docs: add Backstage platform engineering topic

### DIFF
--- a/topics/backstage/README.md
+++ b/topics/backstage/README.md
@@ -1,0 +1,107 @@
+# Backstage
+
+## 1. What is Backstage?
+
+- https://backstage.io/
+
+### Overview
+
+Backstage is an open-source framework for building developer portals. It provides a central place for developers to discover software, understand ownership, use software templates, browse technical documentation, and integrate engineering tools through plugins.
+
+One of its core features is the Software Catalog, which keeps metadata about services, websites, libraries, APIs, systems, resources, users, and groups in a consistent format.
+
+### Official documentation
+
+- https://backstage.io/docs/
+
+## 2. Prerequisites
+
+For a local standalone installation, review the official Backstage prerequisites before starting:
+
+- A Unix-based environment such as Linux, macOS, or Windows Subsystem for Linux (WSL)
+- Node.js Active LTS. Backstage currently recommends Node.js 22 or 24
+- Yarn and Corepack
+- Git
+- Docker
+- At least 6 GB of memory and 20 GB of free disk space for the standalone demo environment
+
+See the official installation guide for the complete and most up-to-date requirements:
+
+- https://backstage.io/docs/getting-started/
+
+## 3. Installation
+
+Create a local Backstage application with the official scaffolding command:
+
+```bash
+npx @backstage/create-app@latest
+```
+
+Enter a name for the application when prompted, for example:
+
+```text
+my-backstage-app
+```
+
+Then start the application:
+
+```bash
+cd my-backstage-app
+yarn start
+```
+
+When the application is ready, open:
+
+```text
+http://localhost:3000
+```
+
+## 4. Basics of Backstage
+
+Backstage organizes software metadata through its Software Catalog. Catalog entities are usually defined in YAML files, and the recommended filename for an entity descriptor is `catalog-info.yaml`.
+
+A basic component contains fields such as:
+
+- `apiVersion`
+- `kind`
+- `metadata`
+- `spec`
+- component type
+- lifecycle
+- owner
+
+Try the runnable example in [`basics/`](./basics/README.md) to create a local Backstage application and register a sample service in the Software Catalog.
+
+Useful documentation:
+
+- https://backstage.io/docs/features/software-catalog/
+- https://backstage.io/docs/features/software-catalog/descriptor-format/
+
+## 5. Beyond the Basics
+
+After becoming familiar with the Software Catalog, explore other Backstage capabilities:
+
+- Software Templates for creating components from reusable templates
+- TechDocs for documentation-as-code
+- Plugins for integrating engineering tools into the developer portal
+- Authentication and authorization
+- Deployment with Docker or Kubernetes
+
+Useful documentation:
+
+- https://backstage.io/docs/features/software-templates/
+- https://backstage.io/docs/features/techdocs/
+- https://backstage.io/plugins/
+- https://backstage.io/docs/deployment/
+
+## 6. More
+
+### Practice
+
+- Continue with the exercises in [`practice/`](./practice/README.md).
+
+### Learning resources
+
+- Backstage documentation: https://backstage.io/docs/
+- Backstage GitHub repository: https://github.com/backstage/backstage
+- Backstage plugin directory: https://backstage.io/plugins/

--- a/topics/backstage/basics/README.md
+++ b/topics/backstage/basics/README.md
@@ -1,0 +1,101 @@
+# Backstage Hello World
+
+This example creates a local Backstage application and registers a sample service in the Software Catalog.
+
+## Prerequisites
+
+Make sure the prerequisites from the [Backstage topic README](../README.md#2-prerequisites) are installed.
+
+## 1. Create a Backstage application
+
+Run:
+
+```bash
+npx @backstage/create-app@latest
+```
+
+When prompted for an application name, use:
+
+```text
+my-backstage-app
+```
+
+The command creates a new `my-backstage-app` directory and installs the required dependencies.
+
+## 2. Add the sample catalog entity
+
+Copy the [`catalog-info.yaml`](./catalog-info.yaml) file from this directory into the root of the generated Backstage application and rename the copy to:
+
+```text
+sample-service.yaml
+```
+
+The generated application should now contain:
+
+```text
+my-backstage-app/
+├── app-config.yaml
+├── sample-service.yaml
+├── package.json
+└── packages/
+```
+
+## 3. Register the sample service
+
+Open `my-backstage-app/app-config.yaml`.
+
+Find the existing `catalog.locations` section and append the following location:
+
+```yaml
+catalog:
+  locations:
+    - type: file
+      target: ../../examples/entities.yaml
+
+    # Keep the other generated locations and add this one.
+    - type: file
+      target: ../../sample-service.yaml
+      rules:
+        - allow: [Component]
+```
+
+Do not create a second `catalog:` key if one already exists. Add the new `file` entry to the existing `catalog.locations` list.
+
+Backstage resolves local file locations relative to the backend process, which normally runs from `packages/backend`. Therefore `../../sample-service.yaml` points to the file in the application root.
+
+## 4. Start Backstage
+
+From the generated application directory, run:
+
+```bash
+cd my-backstage-app
+yarn start
+```
+
+When the frontend finishes starting, open:
+
+```text
+http://localhost:3000
+```
+
+## 5. Verify the service
+
+Open the Software Catalog and search for:
+
+```text
+devops-basics-sample-service
+```
+
+The component should appear with:
+
+- Type: `service`
+- Lifecycle: `experimental`
+- Owner: `guests`
+
+You have now registered a custom service in the Backstage Software Catalog.
+
+## Cleanup
+
+Stop the local Backstage process with `Ctrl+C`.
+
+If the application was created only for this example, you can remove the generated `my-backstage-app` directory afterward.

--- a/topics/backstage/basics/catalog-info.yaml
+++ b/topics/backstage/basics/catalog-info.yaml
@@ -1,0 +1,12 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: devops-basics-sample-service
+  description: Sample service used to demonstrate the Backstage Software Catalog
+  tags:
+    - backstage
+    - devops
+spec:
+  type: service
+  lifecycle: experimental
+  owner: guests

--- a/topics/backstage/practice/README.md
+++ b/topics/backstage/practice/README.md
@@ -1,0 +1,47 @@
+# Backstage Practice
+
+Use these exercises after completing the runnable example in [`../basics/`](../basics/README.md).
+
+## Exercise 1: Register another service
+
+### Goal
+
+Practice creating and registering a new `Component` entity in the Backstage Software Catalog.
+
+### Tasks
+
+1. Create a new YAML file named `second-service.yaml`.
+2. Define a `Component` entity with:
+   - a unique `metadata.name`
+   - a short description
+   - `spec.type` set to `service`
+   - `spec.lifecycle` set to `experimental`
+   - `spec.owner` set to `guests`
+3. Add the file to the existing `catalog.locations` list in `app-config.yaml`.
+4. Start Backstage with `yarn start`.
+5. Confirm that the new component appears in the Software Catalog.
+
+### Expected result
+
+The catalog should show both `devops-basics-sample-service` and the new service you created.
+
+## Exercise 2: Change component metadata
+
+### Goal
+
+See how changes to catalog metadata are reflected in Backstage.
+
+### Tasks
+
+1. Add at least two tags to `second-service.yaml`.
+2. Change its description.
+3. Restart Backstage if necessary.
+4. Open the component in the Software Catalog and verify the updated metadata.
+
+### Challenge
+
+Read the Backstage catalog entity descriptor documentation and add one more supported metadata or specification field to your component.
+
+Documentation:
+
+- https://backstage.io/docs/features/software-catalog/descriptor-format/


### PR DESCRIPTION
Closes: #803

## What is the purpose of the change

This pull request adds a new Backstage topic to the project.

It introduces:

* a main Backstage README covering an overview, prerequisites, installation, basic concepts, and further learning resources
* a runnable Software Catalog example under `topics/backstage/basics/`
* a sample `catalog-info.yaml` component that can be registered in a local Backstage instance
* practice exercises under `topics/backstage/practice/` for creating and updating catalog entities

The example was tested with a locally generated Backstage application and the sample `devops-basics-sample-service` component was successfully registered and displayed in the Software Catalog.
