### PR TITLE
Add FluxCD topic (GitOps / CI-CD)

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,14 @@ We cover a wide range of DevOps topics in our content library, explore them unde
         <td>✔️ <a href="./topics/argocd/practice/">Explore</a></td>
     </tr>
     <tr>
+        <td><img height="28" src="https://avatars.githubusercontent.com/u/52158677?v=4"></td>
+        <td>FluxCD</td>
+        <td><a href="./topics/fluxcd/">fluxcd</a></td>
+        <td>📖 <a href="https://fluxcd.io/docs/">View</a></td>
+        <td>✔️ <a href="./topics/fluxcd/basics/">Explore</a></td>
+        <td>✔️ <a href="./topics/fluxcd/practice/">Explore</a></td>
+    </tr>
+    <tr>
         <td><img height="28" src="https://skillicons.dev/icons?i=githubactions" /></td>
         <td>Github-Action</td>
         <td><a href="./topics/github-action/">github-action</a></td>

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -8,6 +8,7 @@ This document outlines the planned improvements and upcoming content for DevOps 
 
 | Topic | Description |
 |-------|-------------|
+| FluxCD | CNCF-graduated GitOps engine, complement to ArgoCD |
 | Grafana | Metrics visualization and dashboards |
 | Vault | HashiCorp Vault secrets management |
 | OpenTofu | Open-source Terraform fork (Linux Foundation) |
@@ -20,7 +21,6 @@ These are planned or in-progress based on community demand and industry relevanc
 
 | Topic | Category | Priority | Notes |
 |-------|----------|----------|-------|
-| **FluxCD** | GitOps / CI-CD | High | CNCF-graduated GitOps engine, complement to ArgoCD |
 | **Crossplane** | IaC / Platform Eng | High | Kubernetes-native infrastructure management |
 | **Backstage** | Platform Engineering | High | Developer portal framework by Spotify |
 | **Dagger** | CI/CD | Medium | Portable CI/CD pipelines as code |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -132,6 +132,7 @@ nav:
       - GitHub Actions: topics/github-action/README.md
       - GitLab CI: topics/gitlabci/README.md
       - ArgoCD: topics/argocd/README.md
+      - FluxCD: topics/fluxcd/README.md
     - Containers & Orchestration:
       - Docker: topics/docker/README.md
       - Kubernetes: topics/k8s/README.md

--- a/topics/fluxcd/README.md
+++ b/topics/fluxcd/README.md
@@ -1,0 +1,177 @@
+## 1. What is FluxCD?
+
+- https://fluxcd.io/docs/
+
+### Overview
+
+Flux is a CNCF-graduated, GitOps continuous delivery tool for Kubernetes. It keeps a cluster's state in sync with a source of truth stored in Git (or an OCI artifact / Helm repository) — you declare what you want deployed, Flux reconciles the cluster to match, on a schedule and automatically, with no `kubectl apply` in your deploy pipeline.
+
+Flux is built as a set of specialized Kubernetes controllers, each with its own CRDs:
+
+- **source-controller** — fetches artifacts (Git repos, Helm repos, OCI repos, S3 buckets) and makes them available as revisions
+- **kustomize-controller** — applies Kustomize overlays from a source to the cluster, and prunes resources removed from Git
+- **helm-controller** — reconciles `HelmRelease` resources by installing/upgrading Helm charts from a source
+- **notification-controller** — sends events to Slack, Discord, webhooks, etc. and receives inbound webhooks to trigger reconciliation
+
+This is the same category as ArgoCD (see the [`argocd`](../argocd/) topic) — both are GitOps engines for Kubernetes — but Flux is CLI/CRD-first (no bundled UI by default) and composes independent controllers you can install individually, rather than one monolithic application.
+
+### FluxCD Architecture
+
+```
+ Git repo / Helm repo / OCI repo / S3 bucket
+             │
+             │ polls on --interval
+             ▼
+     ┌───────────────────┐
+     │  source-controller │  fetches + verifies, exposes as a
+     │                    │  versioned "Artifact"
+     └─────────┬──────────┘
+               │ Artifact (revision)
+     ┌─────────┴──────────┐        ┌──────────────────────┐
+     │ kustomize-controller│        │   helm-controller     │
+     │  applies Kustomize   │       │  installs/upgrades    │
+     │  overlays, prunes    │       │  HelmReleases         │
+     │  removed resources   │       │                       │
+     └─────────┬────────────┘       └───────────┬───────────┘
+               │                                 │
+               └───────────────┬─────────────────┘
+                                ▼
+                        Kubernetes cluster
+                                │
+                                ▼
+                  ┌──────────────────────────┐
+                  │  notification-controller  │  events out (Slack/
+                  │                           │  webhook), triggers in
+                  └──────────────────────────┘
+```
+
+### Official Documentation
+
+- https://fluxcd.io/docs/
+- GitHub: https://github.com/fluxcd/flux2
+
+## 2. Prerequisites
+
+- A Kubernetes cluster (this topic uses a local [`kind`](../k8s/) cluster — no cloud account needed)
+- `kubectl` configured against that cluster
+- Familiarity with the [`git`](../git/) and [`k8s`](../k8s/) topics helps, but isn't required
+
+## 3. Installation
+
+### How to install the Flux CLI?
+
+```bash
+# macOS / Linux
+curl -s https://fluxcd.io/install.sh | sudo bash
+
+# macOS via Homebrew
+brew install fluxcd/tap/flux
+
+# Verify
+flux version --client
+```
+
+- Official install guide: https://fluxcd.io/flux/installation/
+
+### Check your cluster is ready for Flux
+
+```bash
+flux check --pre
+```
+
+## 4. Basics of FluxCD
+
+### Getting started with FluxCD
+
+- To get started visit [`basics/`](./basics/) — a runnable script that installs Flux's controllers on a local `kind` cluster and syncs a real public repo ([stefanprodan/podinfo](https://github.com/stefanprodan/podinfo)) without needing a GitHub token or full `flux bootstrap`.
+
+### FluxCD Hello World
+
+```bash
+# Install Flux's controllers (source, kustomize, helm, notification)
+flux install
+
+# Point Flux at a Git repo — no PAT needed for a public repo
+flux create source git podinfo \
+  --url=https://github.com/stefanprodan/podinfo \
+  --branch=master \
+  --interval=1m
+
+# Tell Flux to apply a path from that repo, and keep the cluster in sync
+flux create kustomization podinfo \
+  --target-namespace=default \
+  --source=podinfo \
+  --path="./kustomize" \
+  --prune=true \
+  --interval=10m
+
+# Watch it reconcile
+flux get sources git
+flux get kustomizations
+kubectl get deployments -n default
+```
+
+## 5. Beyond the Basics
+
+### `flux bootstrap` — the production pattern
+
+The commands above (`flux create source git` + `flux create kustomization`) are the fastest way to see Flux work, but production setups almost always use `flux bootstrap`, which additionally:
+
+- commits Flux's own manifests into your Git repo (so Flux manages itself via GitOps too)
+- sets up a deploy key / GitHub App so Flux can push status commits back
+- is idempotent — safe to re-run against an existing cluster
+
+```bash
+export GITHUB_TOKEN=<your-pat>
+flux bootstrap github \
+  --owner=<your-github-username> \
+  --repository=<your-fleet-repo> \
+  --branch=main \
+  --path=clusters/my-cluster \
+  --personal
+```
+
+### Multi-tenancy and multiple environments
+
+Flux's `Kustomization` and `GitRepository` are namespaced CRDs, so a common pattern is one `flux-system` per cluster with per-team or per-environment `Kustomization`s pointing at different paths (`clusters/staging`, `clusters/production`) of the same monorepo — see the [official multi-tenancy guide](https://fluxcd.io/flux/installation/configuration/multitenancy/).
+
+### Automating image updates
+
+Flux's [image automation controllers](https://fluxcd.io/flux/components/image/) can watch a container registry and open a commit against your Git repo whenever a new image tag matching a policy is pushed — closing the loop from CI (build+push image) to CD (Flux picks it up) without a separate deploy step.
+
+### Hands-On Examples
+
+- See: [practice/](./practice/)
+
+## 6. More
+
+### FluxCD Cheatsheet
+
+```bash
+# Sources
+flux get sources git                    # list Git sources and their sync status
+flux reconcile source git podinfo       # force an immediate re-sync
+
+# Kustomizations
+flux get kustomizations                 # list Kustomizations and their apply status
+flux reconcile kustomization podinfo    # force an immediate re-apply
+flux suspend kustomization podinfo      # pause reconciliation
+flux resume kustomization podinfo       # resume reconciliation
+
+# Everything at once
+flux get all -A
+
+# Logs (useful when a Kustomization is stuck)
+flux logs --follow --tail=50
+
+# Tear down
+flux delete kustomization podinfo
+flux delete source git podinfo
+flux uninstall --namespace=flux-system
+```
+
+### Recommended Resources
+
+- [Flux Documentation](https://fluxcd.io/docs/)
+- [Flux GitHub](https://github.com/fluxcd/flux2)
+- [Flux vs ArgoCD comparison (official FAQ)](https://fluxcd.io/docs/faq/#flux-vs-argo-cd)

--- a/topics/fluxcd/basics/README.md
+++ b/topics/fluxcd/basics/README.md
@@ -1,0 +1,22 @@
+# Basics of FluxCD
+
+## Demo
+
+Run `./fluxcd_sync_demo.sh` to spin up (or reuse) a local `kind` cluster, install Flux's controllers, and point Flux at a real public Git repo ([stefanprodan/podinfo](https://github.com/stefanprodan/podinfo)) — no GitHub token and no full `flux bootstrap` needed for this demo. You'll see Flux fetch the repo, apply its Kubernetes manifests, and bring up a running deployment, purely from a Git source it polls on an interval.
+
+### Requirements
+
+- `docker`
+- `kind` (the script creates a `fluxcd-demo` cluster if one doesn't already exist — https://kind.sigs.k8s.io/docs/user/quick-start/#installation)
+- `kubectl`
+- `flux` CLI (see the [installation section](../README.md#3-installation) in the parent topic)
+
+### Cleanup
+
+The script prints the teardown commands at the end rather than running them automatically, so you can poke around the live cluster first:
+
+```bash
+flux delete kustomization podinfo --silent
+flux delete source git podinfo --silent
+kind delete cluster --name fluxcd-demo
+```

--- a/topics/fluxcd/basics/fluxcd_sync_demo.sh
+++ b/topics/fluxcd/basics/fluxcd_sync_demo.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+# FluxCD Sync Demo - installs Flux on a local kind cluster and syncs a real
+# public repo (stefanprodan/podinfo) via GitRepository + Kustomization,
+# with no GitHub token and no full `flux bootstrap` required.
+
+set -e
+
+CLUSTER_NAME="fluxcd-demo"
+
+echo "==> flux version:"
+flux version --client
+
+echo ""
+echo "=============================="
+echo "1. Ensuring a local cluster exists"
+echo "=============================="
+if kubectl config get-contexts "kind-${CLUSTER_NAME}" >/dev/null 2>&1; then
+  echo "Reusing existing kind cluster: ${CLUSTER_NAME}"
+  kubectl config use-context "kind-${CLUSTER_NAME}"
+else
+  echo "Creating kind cluster: ${CLUSTER_NAME}"
+  kind create cluster --name "${CLUSTER_NAME}"
+fi
+
+echo ""
+echo "=============================="
+echo "2. Checking cluster prerequisites"
+echo "=============================="
+flux check --pre
+
+echo ""
+echo "=============================="
+echo "3. Installing Flux controllers"
+echo "=============================="
+flux install
+
+echo ""
+echo "=============================="
+echo "4. Pointing Flux at a public Git repo"
+echo "=============================="
+flux create source git podinfo \
+  --url=https://github.com/stefanprodan/podinfo \
+  --branch=master \
+  --interval=1m
+
+echo ""
+echo "=============================="
+echo "5. Telling Flux to apply and keep this path in sync"
+echo "=============================="
+flux create kustomization podinfo \
+  --target-namespace=default \
+  --source=podinfo \
+  --path="./kustomize" \
+  --prune=true \
+  --interval=10m
+
+echo ""
+echo "=============================="
+echo "6. Watching it reconcile"
+echo "=============================="
+flux get sources git
+flux get kustomizations
+
+echo ""
+echo "Waiting for the synced deployment to become available..."
+kubectl wait --for=condition=available --timeout=120s deployment/podinfo -n default
+
+kubectl get deployments -n default
+kubectl get pods -n default
+
+echo ""
+echo "==> Done! Flux fetched podinfo from Git and reconciled it onto the cluster."
+echo "==> Tip: edit anything under ./kustomize in a fork of the repo, push, and"
+echo "    wait up to the --interval — Flux picks the change up automatically."
+echo ""
+echo "==> Cleanup:"
+echo "    flux delete kustomization podinfo --silent"
+echo "    flux delete source git podinfo --silent"
+echo "    kind delete cluster --name ${CLUSTER_NAME}"

--- a/topics/fluxcd/practice/README.md
+++ b/topics/fluxcd/practice/README.md
@@ -1,0 +1,12 @@
+## FluxCD practice
+
+1. **Fork-and-sync**: fork [stefanprodan/podinfo](https://github.com/stefanprodan/podinfo), point your `GitRepository` source at your fork instead of the upstream repo (`flux create source git podinfo --url=https://github.com/<you>/podinfo ...`), then edit a value under `kustomize/` (e.g. `replicaCount` via a `kustomization.yaml` patch) and push. Watch `flux get kustomizations --watch` pick up the new revision within the `--interval` window, without ever running `kubectl apply` yourself.
+
+2. **Prune in action**: with the demo running, delete one of the manifests from your forked repo's `kustomize/` path and push. Run `flux reconcile kustomization podinfo` and confirm with `kubectl get all -n default` that Flux removed the corresponding resource from the cluster — this is what `--prune=true` buys you over a one-shot `kubectl apply -k`.
+
+3. **Break it, then read the logs**: point a `GitRepository` at a branch or path that doesn't exist (`--branch=does-not-exist`) and observe `flux get sources git` report `Ready: False`. Use `flux logs --level=error` to find the actual error, then fix the source and confirm it recovers on its own — no manual intervention beyond fixing the config.
+
+4. **ArgoCD side-by-side**: if you've done the [`argocd`](../../argocd/) topic, compare the two mental models — ArgoCD's `Application` CRD couples "what to sync" and "where from" in one object with a UI on top, while Flux splits "where from" (`GitRepository`/`HelmRepository`/`OCIRepository`) from "what to do with it" (`Kustomization`/`HelmRelease`) as separate, composable CRDs. Write down one scenario where that separation is genuinely useful (hint: one source, multiple environments).
+
+- Official Flux GitOps guides: https://fluxcd.io/flux/guides/
+- Flux vs ArgoCD FAQ: https://fluxcd.io/docs/faq/#flux-vs-argo-cd

--- a/topics/index.md
+++ b/topics/index.md
@@ -49,6 +49,14 @@ Browse **40+ topics** organized by category. Each topic includes official docs, 
 
     [:octicons-book-16: Docs](https://argo-cd.readthedocs.io/en/stable/) &nbsp;·&nbsp; [:octicons-code-16: Basics](argocd/basics/) &nbsp;·&nbsp; [:octicons-beaker-16: Practice](argocd/practice/)
 
+-   :simple-flux: **FluxCD**
+
+    ---
+
+    CNCF-graduated GitOps engine — composable controllers sync a cluster to Git.
+
+    [:octicons-book-16: Docs](https://fluxcd.io/docs/) &nbsp;·&nbsp; [:octicons-code-16: Basics](fluxcd/basics/) &nbsp;·&nbsp; [:octicons-beaker-16: Practice](fluxcd/practice/)
+
 </div>
 
 ---


### PR DESCRIPTION
Closes #801.

## Summary

Adds a `topics/fluxcd/` topic following the existing structure (see `topics/grafana` / `topics/trivy` as the reference), and wires it into the repo's navigation.

- **`topics/fluxcd/README.md`** — What is FluxCD, controller architecture (ASCII diagram), install, a runnable basics walkthrough, a "Beyond the Basics" section covering `flux bootstrap` / multi-tenancy / image automation, and a cheatsheet — same six-section shape as the other recently-added topics.
- **`topics/fluxcd/basics/fluxcd_sync_demo.sh`** — installs Flux's controllers on a local `kind` cluster and syncs a real public repo ([stefanprodan/podinfo](https://github.com/stefanprodan/podinfo)) via `GitRepository` + `Kustomization`. No GitHub token and no full `flux bootstrap` needed, per the issue's suggested approach.
- **`topics/fluxcd/practice/README.md`** — 4 exercises: fork-and-sync, watching `--prune` remove a deleted resource, deliberately breaking a source and reading `flux logs` to recover it, and a compare-and-contrast writing prompt against the existing ArgoCD topic.
- Added to `mkdocs.yml` nav (under CI/CD, after ArgoCD), `topics/index.md`'s card grid, `README.md`'s topic table, and moved FluxCD from ROADMAP.md's "Upcoming" to "Recently Added".

## Test plan

- [x] Ran the exact committed `fluxcd_sync_demo.sh` twice end-to-end against a real `kind` cluster on this machine — once creating a fresh cluster, once reusing an existing one. Both times Flux fetched `podinfo`, applied its manifests, and the deployment reached `2/2 Available`.
- [x] Verified the practice exercise's "break a source, read the logs, it self-heals" scenario against real `flux` output (bad branch → `Ready: False` with a clear message; `flux logs --level=error` surfaces the exact error).
- [x] `shellcheck topics/fluxcd/basics/fluxcd_sync_demo.sh` — clean.
- [x] `mkdocs build --strict` — no new warnings introduced (the 5 pre-existing warnings on `main` are unrelated: root/`topics/` README-vs-index.md conflicts and two pre-existing broken image links in `argocd`/`elk`, all present before this PR too).
- [x] Followed [CONTRIBUTING.md](https://github.com/tungbq/devops-basics/blob/main/CONTRIBUTING.md)'s flow.